### PR TITLE
Added extra checks to prevent wrong output

### DIFF
--- a/sitemap-dynamic.ts
+++ b/sitemap-dynamic.ts
@@ -46,13 +46,17 @@ export default defineNuxtModule({
     nuxt.hook('nitro:build:before', (nitro) => {
       const paths = []
       nitro.hooks.hook('prerender:route', (route) => {
-        if (!route.route.includes('/api/_content')) {
+        // Exclude paths which contain /api/_content, _payload.js and the standard 200.html entry point
+        // None of these should be in the sitemap.xml file
+        if (!route.route.includes('/api/_content') && !route.route.includes('_payload.js') && !route.route.includes('200.html')) {
           paths.push({ path: route.route })
         }
       })
       nitro.hooks.hook('close', async () => {
         const sitemap = await generateSitemap(paths)
         createSitemapFile(sitemap, filePath)
+        // Added output to confirm that the sitemap has been created at the end of the build process
+        console.log('Sitemap created')
       })
     })
   },

--- a/sitemap-dynamic.ts
+++ b/sitemap-dynamic.ts
@@ -45,10 +45,12 @@ export default defineNuxtModule({
 
     nuxt.hook('nitro:build:before', (nitro) => {
       const paths = []
+      const EXCLUDED_KEYWORDS = ['/api/_content', '_payload.js', '200.html']
       nitro.hooks.hook('prerender:route', (route) => {
         // Exclude paths which contain /api/_content, _payload.js and the standard 200.html entry point
         // None of these should be in the sitemap.xml file
-        if (!route.route.includes('/api/_content') && !route.route.includes('_payload.js') && !route.route.includes('200.html')) {
+        const shouldBeAddedToSitemap = EXCLUDED_KEYWORDS.every((excudedKeyword) => !route.route.includes(excudedKeyword))
+        if (shouldBeAddedToSitemap) {
           paths.push({ path: route.route })
         }
       })

--- a/sitemap.ts
+++ b/sitemap.ts
@@ -46,6 +46,8 @@ export default defineNuxtModule({
     nuxt.hook('pages:extend', async pages => {
       const sitemap = await generateSitemap(pages)
       createSitemapFile(sitemap, filePath)
+      // Added output to confirm that the sitemap has been created at the end of the build process
+      console.log('Sitemap created')
     })
   },
 })


### PR DESCRIPTION
This PR is meant to fix the issue where generating a sitemap while using Nuxt/Content would lead to extra URLs being added to the `sitemap.xml` file. The URLs specifically contained:

- `_payload.js`
- `200.html`

Both should not be in the final sitemap.